### PR TITLE
refactor : Security 도메인 코틀린 전환

### DIFF
--- a/src/main/java/com/back/pinco/global/exception/ErrorCode.kt
+++ b/src/main/java/com/back/pinco/global/exception/ErrorCode.kt
@@ -1,10 +1,14 @@
-package com.back.pinco.global.exception;
+package com.back.pinco.global.exception
 
-import lombok.Getter;
-import org.springframework.http.HttpStatus;
+import lombok.Getter
+import org.springframework.http.HttpStatus
 
 @Getter
-public enum ErrorCode {
+enum class ErrorCode(
+    val code: Int,
+    val status: HttpStatus,
+    val message: String
+) {
 
     // 공통 0000번대
     SUCCESS(200, HttpStatus.OK, "성공적으로 처리되었습니다."),
@@ -71,29 +75,5 @@ public enum ErrorCode {
     LIKES_UPDATE_PIN_FAILED(5005, HttpStatus.NOT_FOUND, "좋아요 갱신 중 오류가 발생했습니다."),
     LIKES_NOT_FOUND(5006, HttpStatus.NOT_FOUND, "존재하지 않는 좋아요입니다."),
     ;
-
-
-
-    private final int code;
-    private final HttpStatus status;
-    private final String message;
-
-    ErrorCode(int code, HttpStatus status, String message) {
-        this.code = code;
-        this.status = status;
-        this.message = message;
-    }
-
-    public int getCode() {
-        return code;
-    }
-
-    public HttpStatus getStatus() {
-        return status;
-    }
-
-    public String getMessage() {
-        return message;
-    }
 
 }

--- a/src/main/java/com/back/pinco/global/exception/ServiceException.kt
+++ b/src/main/java/com/back/pinco/global/exception/ServiceException.kt
@@ -1,17 +1,9 @@
-package com.back.pinco.global.exception;
+package com.back.pinco.global.exception
 
-import lombok.Getter;
+import lombok.Getter
 
 @Getter
-public class ServiceException extends RuntimeException {
-
-    private final ErrorCode errorCode;
-
-    /**
-     * @param errorCode ErrorCode.ENUM 값
-     */
-    public ServiceException(ErrorCode errorCode) {
-        super("%d : %s".formatted(errorCode.getCode(), errorCode.getMessage()));
-        this.errorCode = errorCode;
-    }
+data class ServiceException(
+    val errorCode: ErrorCode
+) : RuntimeException("${errorCode.code}: ${errorCode.message}") {
 }

--- a/src/main/java/com/back/pinco/global/exception/ValidationField.kt
+++ b/src/main/java/com/back/pinco/global/exception/ValidationField.kt
@@ -1,34 +1,31 @@
-package com.back.pinco.global.exception;
+package com.back.pinco.global.exception
 
-public sealed interface ValidationField
-        permits LatitudeField, LongitudeField, ContentField, UnknownField {
+sealed interface ValidationField {
 
-    String name();
-
-    static ValidationField from(String fieldName) {
-        return switch (fieldName) {
-            case "latitude" -> new LatitudeField();
-            case "longitude" -> new LongitudeField();
-            case "content" -> new ContentField();
-            default -> new UnknownField(fieldName);
-        };
+    companion object {
+        fun from(fieldName: String): ValidationField = when (fieldName) {
+                "latitude" -> LatitudeField
+                "longitude" -> LongitudeField
+                "content" -> ContentField
+                else -> UnknownField(fieldName)
+        }
     }
+
+    fun name(): String
 }
 
-final class LatitudeField implements ValidationField {
-    @Override public String name() { return "latitude"; }
+data object LatitudeField : ValidationField {
+    override fun name(): String = "latitude"
 }
 
-final class LongitudeField implements ValidationField {
-    @Override public String name() { return "longitude"; }
+data object LongitudeField : ValidationField {
+    override fun name(): String = "longitude"
 }
 
-final class ContentField implements ValidationField {
-    @Override public String name() { return "content"; }
+data object ContentField : ValidationField {
+    override fun name(): String = "content"
 }
 
-final class UnknownField implements ValidationField {
-    private final String name;
-    public UnknownField(String name) { this.name = name; }
-    @Override public String name() { return name; }
+data class UnknownField(private val name: String) : ValidationField {
+    override fun name() : String = name
 }

--- a/src/main/java/com/back/pinco/global/security/JwtTokenProvider.kt
+++ b/src/main/java/com/back/pinco/global/security/JwtTokenProvider.kt
@@ -3,6 +3,7 @@ package com.back.pinco.global.security
 import io.jsonwebtoken.JwtException
 import io.jsonwebtoken.JwtParser
 import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.Jwts.parser
 import io.jsonwebtoken.SignatureAlgorithm
 import io.jsonwebtoken.security.Keys
 import org.springframework.beans.factory.annotation.Value
@@ -24,20 +25,19 @@ class JwtTokenProvider(
     private val refreshExpMs = refreshExpireSeconds * 1000L // 리프레시 토큰 만료(ms)
 
     // 토큰 발급
-    fun generateAccessToken(id: Long?, email: String?, userName: String?): String {
-        return build(
-            accessExpMs, java.util.Map.of<String, Any?>(
-                "id", id,
-                "email", email,
-                "userName", userName,
-                "role", "ROLE_USER"
+    fun generateAccessToken(id: Long?, email: String?, userName: String?): String =
+       build(
+            accessExpMs, mapOf(
+                "id" to id,
+                "email" to email,
+                "userName" to userName,
+                "role" to "ROLE_USER"
             )
         )
-    }
 
-    fun generateRefreshToken(id: Long?): String {
-        return build(refreshExpMs, java.util.Map.of<String, Any?>("id", id))
-    }
+
+    fun generateRefreshToken(id: Long?): String = build(refreshExpMs, mapOf("id" to id))
+
 
     private fun build(expMs: Long, claims: Map<String, Any?>): String {
         val now = Date()
@@ -62,27 +62,26 @@ class JwtTokenProvider(
         }
     }
 
-    fun getUserId(token: String?): Long {
+    fun getUserId(token: String): Long {
         return parser().parseClaimsJws(token).body.subject.toLong()
     }
 
     fun payloadOrNull(token: String?): Map<String, Any>? {
         try {
             val c = parser().parseClaimsJws(token).body
-            return java.util.Map.of(
-                "id", c.subject.toLong(),
-                "email", c.get("email", String::class.java),
-                "userName", c.get("userName", String::class.java),
-                "role", c.getOrDefault("role", "ROLE_USER")
+            return mapOf(
+                "id" to c.subject.toLong(),
+                "email" to c.get("email", String::class.java),
+                "userName" to c.get("userName", String::class.java),
+                "role" to c.getOrDefault("role", "ROLE_USER")
             )
         } catch (e: Exception) {
             return null
         }
     }
 
-    private fun parser(): JwtParser {
-        return Jwts.parserBuilder().setSigningKey(key).build()
-    }
+    private fun parser(): JwtParser = Jwts.parserBuilder().setSigningKey(key).build()
+
 
     // 남은 토큰 유효 시간
     fun getRemainingValidityMillis(token: String?): Long {

--- a/src/main/java/com/back/pinco/global/security/SecurityConfig.kt
+++ b/src/main/java/com/back/pinco/global/security/SecurityConfig.kt
@@ -90,12 +90,12 @@ class SecurityConfig (
         response.writer.write(
             """
             {
-              "errorCode": "%s",
-              "msg": "%s",
+              "errorCode": "${code.code}",
+              "msg": "${code.message}",
               "data": null
             }
             
-            """.trimIndent().formatted(code.code, code.message)
+            """
         )
     }
 
@@ -113,12 +113,12 @@ class SecurityConfig (
         response.writer.write(
             """
             {
-              "errorCode": "%s",
-              "msg": "%s",
+              "errorCode": "${code.code}",
+              "msg": "${code.message}",
               "data": null
             }
             
-            """.trimIndent().formatted(code.code, code.message)
+            """
         )
     }
 }

--- a/src/test/java/com/back/pinco/domain/pin/controller/PinControllerTest.kt
+++ b/src/test/java/com/back/pinco/domain/pin/controller/PinControllerTest.kt
@@ -1,1227 +1,1439 @@
-package com.back.pinco.domain.pin.controller;
+package com.back.pinco.domain.pin.controller
 
-import com.back.pinco.domain.likes.entity.Likes;
-import com.back.pinco.domain.likes.repository.LikesRepository;
-import com.back.pinco.domain.likes.service.LikesService;
-import com.back.pinco.domain.pin.entity.Pin;
-import com.back.pinco.domain.pin.repository.PinRepository;
-import com.back.pinco.domain.pin.service.PinService;
-import com.back.pinco.domain.user.entity.User;
-import com.back.pinco.domain.user.repository.UserRepository;
-import com.back.pinco.domain.user.service.UserService;
-import com.back.pinco.global.exception.ErrorCode;
-import com.back.pinco.global.exception.ServiceException;
-import com.back.pinco.global.security.JwtTokenProvider;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.matchesPattern;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
+import com.back.pinco.domain.likes.repository.LikesRepository
+import com.back.pinco.domain.likes.service.LikesService
+import com.back.pinco.domain.pin.repository.PinRepository
+import com.back.pinco.domain.pin.service.PinService
+import com.back.pinco.domain.user.entity.User
+import com.back.pinco.domain.user.repository.UserRepository
+import com.back.pinco.domain.user.service.UserService
+import com.back.pinco.global.exception.ErrorCode
+import com.back.pinco.global.exception.ServiceException
+import com.back.pinco.global.security.JwtTokenProvider
+import org.assertj.core.api.Assertions
+import org.hamcrest.Matchers
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.transaction.annotation.Transactional
+import java.util.function.Supplier
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
-public class PinControllerTest {
+class PinControllerTest {
     @Autowired
-    private MockMvc mvc;
-    @Autowired
-    private PinRepository pinRepository;
+    private lateinit var mvc: MockMvc
 
     @Autowired
-    private UserRepository userRepository;
+    private lateinit var pinRepository: PinRepository
 
     @Autowired
-    private JwtTokenProvider jwtTokenProvider;
+    private lateinit var userRepository: UserRepository
 
     @Autowired
-    private PinService pinService;
+    private lateinit var jwtTokenProvider: JwtTokenProvider
 
     @Autowired
-    private LikesRepository likesRepository;
+    private lateinit var pinService: PinService
 
     @Autowired
-    private UserService userService;
+    private lateinit var likesRepository: LikesRepository
 
     @Autowired
-    private LikesService likesService;
+    private lateinit var userService: UserService
+
+    @Autowired
+    private lateinit var likesService: LikesService
 
 
-    long targetId = 1L;
-    long failedTargetId = Integer.MAX_VALUE;
+    var targetId: Long = 1L
+    var failedTargetId: Long = Int.MAX_VALUE.toLong()
 
-    long noAuthId = 4L;
+    var noAuthId: Long = 4L
 
-    private String jwtToken;
-    private User testUser;
+    private lateinit var jwtToken: String
+    private lateinit var testUser: User
 
 
     @BeforeEach
-    void setUp() {
-        testUser = userRepository.findById(1L).get();
-        jwtToken = jwtTokenProvider.generateAccessToken(testUser.getId(), testUser.getEmail(), testUser.getUserName());
+    fun setUp() {
+        testUser = userRepository.findById(1L).get()
+        jwtToken =
+            jwtTokenProvider.generateAccessToken(testUser.id, testUser.email, testUser.userName)
     }
 
 
     @Test
     @DisplayName("핀 생성")
-    void t1_1() throws Exception {
+    @Throws(Exception::class)
+    fun t1_1() {
+        val lat = 0.0
+        val lon = 0.0
+        val content = "new Content!"
 
-        double lat = 0;
-        double lon = 0;
-        String content = "new Content!";
-
-        String jsonContent = String.format(
-                """
+        val jsonContent = String.format(
+            """
                         {
-                            "content": "%s",
-                            "latitude" : %s, 
-                            "longitude" : %s
+                            "content": "$content",
+                            "latitude" : $lat, 
+                            "longitude" : $lon
                         }
-                        """, content, lat, lon
-        );
+                        
+                        """.trimIndent()
+        )
 
-        ResultActions resultActions = mvc
-                .perform(
-                        post("/api/pins")
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(jsonContent)
-                )
-                .andDo(print());
-
-        resultActions
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("createPin"))
-                .andExpect(status().isOk());
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.post("/api/pins")
+                    .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(jsonContent)
+            )
+            .andDo(MockMvcResultHandlers.print())
 
         resultActions
-                .andExpect(jsonPath("$.data.id").isNotEmpty())
-                .andExpect(jsonPath("$.data.latitude").value(lat))
-                .andExpect(jsonPath("$.data.longitude").value(lon))
-                .andExpect(jsonPath("$.data.content").value(content));
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("createPin"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+
+        resultActions
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.id").isNotEmpty())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.latitude").value(lat))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.longitude").value(lon))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.content").value(content))
     }
 
     @Test
     @DisplayName("핀 생성 - 실패 (경도 정보 오류)")
-    void t1_2() throws Exception {
+    @Throws(Exception::class)
+    fun t1_2() {
+        val lat = 0.0
 
-        double lat = 0;
+        val content = "new Content!"
 
-        String content = "new Content!";
-
-        String jsonContent = String.format(
-                """
+        val jsonContent = String.format(
+            """
                         {
-                            "content": "%s",
-                            "latitude" : %s
+                            "content": "$content",
+                            "latitude" : $lat
                         }
-                        """, content, lat
-        );
+                        
+                        """.trimIndent()
+        )
 
-        ResultActions resultActions = mvc
-                .perform(
-                        post("/api/pins")
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(jsonContent)
-                )
-                .andDo(print());
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.post("/api/pins")
+                    .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(jsonContent)
+            )
+            .andDo(MockMvcResultHandlers.print())
 
         resultActions
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("createPin"))
-                .andExpect(jsonPath("$.errorCode").value("1007"))
-                .andExpect(jsonPath("$.msg").exists());
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("createPin"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.errorCode").value("1007"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.msg").exists())
     }
 
     @Test
     @DisplayName("핀 생성 - 실패 (위도 정보 오류)")
-    void t1_3() throws Exception {
+    @Throws(Exception::class)
+    fun t1_3() {
+        val lon = 0.0
+        val content = "new Content!"
 
-        double lon = 0;
-        String content = "new Content!";
-
-        String jsonContent = String.format(
-                """
+        val jsonContent = String.format(
+            """
                         {
-                            "content": "%s",
-                            "longitude" : %s
+                            "content": "$content",
+                            "longitude" : $lon
                         }
-                        """, content, lon
-        );
+                        
+                        """.trimIndent()
+        )
 
-        ResultActions resultActions = mvc
-                .perform(
-                        post("/api/pins")
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(jsonContent)
-                )
-                .andDo(print());
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.post("/api/pins")
+                    .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(jsonContent)
+            )
+            .andDo(MockMvcResultHandlers.print())
 
         resultActions
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("createPin"))
-                .andExpect(jsonPath("$.errorCode").value("1006"))
-                .andExpect(jsonPath("$.msg").exists());
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("createPin"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.errorCode").value("1006"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.msg").exists())
     }
 
     @Test
     @DisplayName("핀 생성 - 실패 (내용 정보 오류)")
-    void t1_4() throws Exception {
+    @Throws(Exception::class)
+    fun t1_4() {
+        val lat = 0.0
+        val lon = 0.0
 
-        double lat = 0;
-        double lon = 0;
-
-        String jsonContent = String.format(
-                """
+        val jsonContent = String.format(
+            """
                         {
-                            "latitude" : %s,
-                            "longitude" : %s
+                            "latitude" : $lat, 
+                            "longitude" : $lon
                         }
-                        """, lat, lon
-        );
+                        
+                        """.trimIndent()
+        )
 
-        ResultActions resultActions = mvc
-                .perform(
-                        post("/api/pins")
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(jsonContent)
-                )
-                .andDo(print());
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.post("/api/pins")
+                    .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(jsonContent)
+            )
+            .andDo(MockMvcResultHandlers.print())
 
         resultActions
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("createPin"))
-                .andExpect(jsonPath("$.errorCode").value("1005"))
-                .andExpect(jsonPath("$.msg").exists());
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("createPin"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.errorCode").value("1005"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.msg").exists())
     }
 
     @Test
     @DisplayName("핀 생성 - 실패 (jwt 없음)")
-    void t1_5() throws Exception {
-        double lat = 0;
-        double lon = 0;
-        String content = "new Content!";
+    @Throws(Exception::class)
+    fun t1_5() {
+        val lat = 0.0
+        val lon = 0.0
+        val content = "new Content!"
 
-        String jsonContent = String.format(
-                """
+        val jsonContent = String.format(
+            """
                         {
-                            "content": "%s",
-                            "latitude" : %s, 
-                            "longitude" : %s
+                            "content": "$content",
+                            "latitude" : $lat, 
+                            "longitude" : $lon
                         }
-                        """, content, lat, lon
-        );
+                        
+                        """.trimIndent()
+        )
 
-        ResultActions resultActions = mvc
-                .perform(
-                        post("/api/pins")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(jsonContent)
-                )
-                .andDo(print());
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.post("/api/pins")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(jsonContent)
+            )
+            .andDo(MockMvcResultHandlers.print())
 
         resultActions
-                .andExpect(status().is(401));
+            .andExpect(MockMvcResultMatchers.status().`is`(401))
     }
 
     @Test
     @DisplayName("id로 핀 조회 - 로그인 - 성공")
-    void t2_1_1() throws Exception {
-
-        Pin pin = pinRepository.findAccessiblePinById(targetId, testUser.getId()).get();
-        ResultActions resultActions = mvc
-                .perform(
-                        get("/api/pins/%s".formatted(targetId))
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                )
-                .andDo(print());
+    @Throws(Exception::class)
+    fun t2_1_1() {
+        val pin = pinRepository.findAccessiblePinById(targetId, testUser.id).get()
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.get("/api/pins/$targetId")
+                    .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+            )
+            .andDo(MockMvcResultHandlers.print())
 
         resultActions
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("getPinById"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.id").value(pin.getId()))
-                .andExpect(jsonPath("$.data.latitude").value(pin.getPoint().getY()))
-                .andExpect(jsonPath("$.data.longitude").value(pin.getPoint().getX()))
-                .andExpect(jsonPath("$.data.createdAt").value(matchesPattern(pin.getCreatedAt().toString().replaceAll("0+$", "") + ".*")))
-                .andExpect(jsonPath("$.data.modifiedAt").value(matchesPattern(pin.getModifiedAt().toString().replaceAll("0+$", "") + ".*")))
-                .andExpect(jsonPath("$.data.pinTags.length()").value(pin.getPinTags().size()))
-        ;
-
-
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("getPinById"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.id").value(pin.id))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.latitude").value(pin.point.y))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.longitude").value(pin.point.x))
+            .andExpect(
+                MockMvcResultMatchers.jsonPath("$.data.createdAt").value(
+                    Matchers.matchesPattern(
+                        pin.createdAt.toString().replace("0+$".toRegex(), "") + ".*"
+                    )
+                )
+            )
+            .andExpect(
+                MockMvcResultMatchers.jsonPath("$.data.modifiedAt").value(
+                    Matchers.matchesPattern(
+                        pin.modifiedAt.toString().replace("0+$".toRegex(), "") + ".*"
+                    )
+                )
+            )
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.pinTags.length()").value(pin.pinTags.size))
     }
 
     @Test
     @DisplayName("id로 핀 조회 - 비 로그인 - 성공")
-    void t2_1_2() throws Exception {
+    @Throws(Exception::class)
+    fun t2_1_2() {
+        val pin = pinRepository.findPublicPinById(targetId).get()
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.get("/api/pins/$targetId")
 
-        Pin pin = pinRepository.findPublicPinById(targetId).get();
-        ResultActions resultActions = mvc
-                .perform(
-                        get("/api/pins/%s".formatted(targetId))
-
-                )
-                .andDo(print());
+            )
+            .andDo(MockMvcResultHandlers.print())
 
         resultActions
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("getPinById"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.id").value(pin.getId()))
-                .andExpect(jsonPath("$.data.latitude").value(pin.getPoint().getY()))
-                .andExpect(jsonPath("$.data.longitude").value(pin.getPoint().getX()))
-                .andExpect(jsonPath("$.data.createdAt").value(matchesPattern(pin.getCreatedAt().toString().replaceAll("0+$", "") + ".*")))
-                .andExpect(jsonPath("$.data.modifiedAt").value(matchesPattern(pin.getModifiedAt().toString().replaceAll("0+$", "") + ".*")))
-                .andExpect(jsonPath("$.data.pinTags.length()").value(pin.getPinTags().size()))
-        ;
-
-
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("getPinById"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.id").value(pin.id))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.latitude").value(pin.point.y))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.longitude").value(pin.point.x))
+            .andExpect(
+                MockMvcResultMatchers.jsonPath("$.data.createdAt").value(
+                    Matchers.matchesPattern(
+                        pin.createdAt.toString().replace("0+$".toRegex(), "") + ".*"
+                    )
+                )
+            )
+            .andExpect(
+                MockMvcResultMatchers.jsonPath("$.data.modifiedAt").value(
+                    Matchers.matchesPattern(
+                        pin.modifiedAt.toString().replace("0+$".toRegex(), "") + ".*"
+                    )
+                )
+            )
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.pinTags.length()").value(pin.pinTags.size))
     }
 
     @Test
     @DisplayName("id로 핀 조회 - 로그인 - 실패 (id가 없음)")
-    void t2_2() throws Exception {
-        ResultActions resultActions = mvc
-                .perform(
-                        get("/api/pins/%s".formatted(failedTargetId))
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                )
-                .andDo(print());
+    @Throws(Exception::class)
+    fun t2_2() {
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.get("/api/pins/$failedTargetId")
+                    .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+            )
+            .andDo(MockMvcResultHandlers.print())
 
         resultActions
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("getPinById"))
-                .andExpect(jsonPath("$.errorCode").value("1002"))
-                .andExpect(jsonPath("$.msg").exists());
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("getPinById"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.errorCode").value("1002"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.msg").exists())
     }
 
     @Test
     @DisplayName("id로 핀 조회 - 비로그인 - 실패 (id가 없음)")
-    void t2_3() throws Exception {
-        ResultActions resultActions = mvc
-                .perform(
-                        get("/api/pins/%s".formatted(failedTargetId))
-                )
-                .andDo(print());
+    @Throws(Exception::class)
+    fun t2_3() {
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.get("/api/pins/$failedTargetId")
+            )
+            .andDo(MockMvcResultHandlers.print())
 
         resultActions
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("getPinById"))
-                .andExpect(jsonPath("$.errorCode").value("1002"))
-                .andExpect(jsonPath("$.msg").exists());
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("getPinById"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.errorCode").value("1002"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.msg").exists())
     }
 
     @Test
     @DisplayName("특정 지점에서 범위 내 좌표 확인")
-    void t3_1_1() throws Exception {
+    @Throws(Exception::class)
+    fun t3_1_1() {
+        val pin = pinRepository.findById(targetId).get()
+        val pins = pinRepository.findPinsWithinRadius(
+            pin.point.x,
+            pin.point.y,
+            1000.0,
+            testUser.id
+        )
 
-        Pin pin = pinRepository.findById(targetId).get();
-        List<Pin> pins = pinRepository.findPinsWithinRadius(pin.getPoint().getX(), pin.getPoint().getY(), 1000.0, testUser.getId());
-
-        ResultActions resultActions = mvc
-                .perform(
-                        get("/api/pins")
-                                .param("radius", String.valueOf(1000))
-                                .param("longitude", String.valueOf(pin.getPoint().getX()))
-                                .param("latitude", String.valueOf(pin.getPoint().getY()))
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                )
-                .andDo(print());
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.get("/api/pins")
+                    .param("radius", 1000.toString())
+                    .param("longitude", pin.point.x.toString())
+                    .param("latitude", pin.point.y.toString())
+                    .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+            )
+            .andDo(MockMvcResultHandlers.print())
 
         resultActions
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("getRadiusPins"))
-                .andExpect(status().isOk());
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("getRadiusPins"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
 
-        for (int i = 0; i < pins.size(); i++) {
+        for (i in pins.indices) {
             resultActions
-                    .andExpect(jsonPath("$.data[%d].id".formatted(i)).value(pins.get(i).getId()))
-                    .andExpect(jsonPath("$.data[%d].latitude".formatted(i)).value(pins.get(i).getPoint().getY()))
-                    .andExpect(jsonPath("$.data[%d].longitude".formatted(i)).value(pins.get(i).getPoint().getX()))
-                    .andExpect(jsonPath("$.data[%d].createdAt".formatted(i)).value(matchesPattern(pins.get(i).getCreatedAt().toString().replaceAll("0+$", "") + ".*")))
-                    .andExpect(jsonPath("$.data[%d].modifiedAt".formatted(i)).value(matchesPattern(pins.get(i).getModifiedAt().toString().replaceAll("0+$", "") + ".*")))
-                    .andExpect(jsonPath("$.data[%d].pinTags.length()".formatted(i)).value(pins.get(i).getPinTags().size()));
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[$i].id").value(pins[i].id))
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].latitude")
+                        .value(pins[i].point.y)
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].longitude")
+                        .value(pins[i].point.x)
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].createdAt").value(
+                        Matchers.matchesPattern(
+                            pins[i].createdAt.toString().replace("0+$".toRegex(), "") + ".*"
+                        )
+                    )
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].modifiedAt").value(
+                        Matchers.matchesPattern(
+                            pins[i].modifiedAt.toString().replace("0+$".toRegex(), "") + ".*"
+                        )
+                    )
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].pinTags.length()")
+                        .value(pins[i].pinTags.size)
+                )
         }
-
     }
 
     @Test
     @DisplayName("특정 지점에서 범위 내 좌표 확인- 비로그인")
-    void t3_1_2() throws Exception {
+    @Throws(Exception::class)
+    fun t3_1_2() {
+        val pin = pinRepository.findById(targetId).get()
+        val pins = pinRepository.findPublicPinsWithinRadius(pin.point.x, pin.point.y, 1000.0)
 
-        Pin pin = pinRepository.findById(targetId).get();
-        List<Pin> pins = pinRepository.findPublicPinsWithinRadius(pin.getPoint().getX(),pin.getPoint().getY(),1000.0);
-
-        ResultActions resultActions = mvc
-                .perform(
-                        get("/api/pins")
-                                .param("radius", String.valueOf(1000))
-                                .param("longitude", String.valueOf(pin.getPoint().getX()))
-                                .param("latitude", String.valueOf(pin.getPoint().getY()))
-                )
-                .andDo(print());
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.get("/api/pins")
+                    .param("radius", 1000.toString())
+                    .param("longitude", pin.point.x.toString())
+                    .param("latitude", pin.point.y.toString())
+            )
+            .andDo(MockMvcResultHandlers.print())
 
         resultActions
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("getRadiusPins"))
-                .andExpect(status().isOk());
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("getRadiusPins"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
 
-        for (int i = 0; i < pins.size(); i++) {
+        for (i in pins.indices) {
             resultActions
-                    .andExpect(jsonPath("$.data[%d].id".formatted(i)).value(pins.get(i).getId()))
-                    .andExpect(jsonPath("$.data[%d].latitude".formatted(i)).value(pins.get(i).getPoint().getY()))
-                    .andExpect(jsonPath("$.data[%d].longitude".formatted(i)).value(pins.get(i).getPoint().getX()))
-                    .andExpect(jsonPath("$.data[%d].createdAt".formatted(i)).value(matchesPattern(pins.get(i).getCreatedAt().toString().replaceAll("0+$", "") + ".*")))
-                    .andExpect(jsonPath("$.data[%d].modifiedAt".formatted(i)).value(matchesPattern(pins.get(i).getModifiedAt().toString().replaceAll("0+$", "") + ".*")))
-                    .andExpect(jsonPath("$.data[%d].pinTags.length()".formatted(i)).value(pins.get(i).getPinTags().size()));
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[$i].id").value(pins[i].id))
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].latitude")
+                        .value(pins[i].point.y)
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].longitude")
+                        .value(pins[i].point.x)
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].createdAt").value(
+                        Matchers.matchesPattern(
+                            pins[i].createdAt.toString().replace("0+$".toRegex(), "") + ".*"
+                        )
+                    )
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].modifiedAt").value(
+                        Matchers.matchesPattern(
+                            pins[i].modifiedAt.toString().replace("0+$".toRegex(), "") + ".*"
+                        )
+                    )
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].pinTags.length()")
+                        .value(pins[i].pinTags.size)
+                )
         }
-
     }
 
     @Test
     @DisplayName("특정 지점에서 범위 내 핀 확인 - 핀 없음")
-    void t3_2() throws Exception {
+    @Throws(Exception::class)
+    fun t3_2() {
         // 핀이 없는 위치와 반경을 설정합니다.
-        double outOfRangeLat = 0;
-        double outOfRangeLon = 0;
-        double radius = 10; // 10미터
+        val outOfRangeLat = 0.0
+        val outOfRangeLon = 0.0
+        val radius = 10.0 // 10미터
 
-        ResultActions resultActions = mvc
-                .perform(
-                        get("/api/pins")
-                                .param("radius", String.valueOf(radius))
-                                .param("latitude", String.valueOf(outOfRangeLat))
-                                .param("longitude", String.valueOf(outOfRangeLon))
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                )
-                .andDo(print());
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.get("/api/pins")
+                    .param("radius", radius.toString())
+                    .param("latitude", outOfRangeLat.toString())
+                    .param("longitude", outOfRangeLon.toString())
+                    .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+            )
+            .andDo(MockMvcResultHandlers.print())
 
         resultActions
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("getRadiusPins"))
-                .andExpect(jsonPath("$.errorCode").value("200"))
-                .andExpect(jsonPath("$.msg").exists())
-                .andExpect(jsonPath("$.data").isEmpty());
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("getRadiusPins"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.errorCode").value("200"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.msg").exists())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data").isEmpty())
     }
 
     @Test
     @DisplayName("특정 범위(사각형) 내 좌표 확인 - 로그인 - 사각형")
-    void t3_3_1() throws Exception {
+    @Throws(Exception::class)
+    fun t3_3_1() {
+        val pin = pinRepository.findAll()[0]
+        val centerLat = pin.point.y
+        val centerLon = pin.point.x
 
-        Pin pin = pinRepository.findAll().get(0);
-        double centerLat = pin.getPoint().getY();
-        double centerLon = pin.getPoint().getX();
+        val delta = 0.01 // 대략 1km 정도의 범위
+        val latMax = centerLat + delta
+        val latMin = centerLat - delta
+        val lonMax = centerLon + delta
+        val lonMin = centerLon - delta
 
-        double delta = 0.01; // 대략 1km 정도의 범위
-        double latMax = centerLat + delta;
-        double latMin = centerLat - delta;
-        double lonMax = centerLon + delta;
-        double lonMin = centerLon - delta;
+        val pins = pinRepository.findScreenPins(latMax, lonMax, latMin, lonMin, testUser.id)
 
-        List<Pin> pins = pinRepository.findScreenPins(latMax, lonMax, latMin, lonMin, testUser.getId());
-
-        ResultActions resultActions = mvc
-                .perform(
-                        get("/api/pins/screen")
-                                .param("latMax", String.valueOf(latMax))
-                                .param("latMin", String.valueOf(latMin))
-                                .param("lonMax", String.valueOf(lonMax))
-                                .param("lonMin", String.valueOf(lonMin))
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                )
-                .andDo(print());
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.get("/api/pins/screen")
+                    .param("latMax", latMax.toString())
+                    .param("latMin", latMin.toString())
+                    .param("lonMax", lonMax.toString())
+                    .param("lonMin", lonMin.toString())
+                    .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+            )
+            .andDo(MockMvcResultHandlers.print())
 
         resultActions
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("getRectanglePins"))
-                .andExpect(status().isOk());
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("getRectanglePins"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
 
-        // 반환된 데이터의 개수 검증
-        resultActions.andExpect(jsonPath("$.data.length()").value(pins.size()));
-
-        // 개별 요소 검증
-        for (int i = 0; i < pins.size(); i++) {
-            Pin p = pins.get(i);
+        // 반환된 데이터 검증
+        resultActions.andExpect(MockMvcResultMatchers.jsonPath("$.data.length()").value(pins.size))
+        for (i in pins.indices) {
             resultActions
-                    .andExpect(jsonPath("$.data[%d].id".formatted(i)).value(p.getId()))
-                    .andExpect(jsonPath("$.data[%d].latitude".formatted(i)).value(p.getPoint().getY()))
-                    .andExpect(jsonPath("$.data[%d].longitude".formatted(i)).value(p.getPoint().getX()))
-                    .andExpect(jsonPath("$.data[%d].pinTags.length()".formatted(i)).value(p.getPinTags().size()))
-                    .andExpect(jsonPath("$.data[%d].createdAt".formatted(i))
-                            .value(matchesPattern(p.getCreatedAt().toString().replaceAll("0+$", "") + ".*")))
-                    .andExpect(jsonPath("$.data[%d].modifiedAt".formatted(i))
-                            .value(matchesPattern(p.getModifiedAt().toString().replaceAll("0+$", "") + ".*")));
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[$i].id").value(pins[i].id))
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].latitude")
+                        .value(pins[i].point.y)
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].longitude")
+                        .value(pins[i].point.x)
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].createdAt").value(
+                        Matchers.matchesPattern(
+                            pins[i].createdAt.toString().replace("0+$".toRegex(), "") + ".*"
+                        )
+                    )
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].modifiedAt").value(
+                        Matchers.matchesPattern(
+                            pins[i].modifiedAt.toString().replace("0+$".toRegex(), "") + ".*"
+                        )
+                    )
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].pinTags.length()")
+                        .value(pins[i].pinTags.size)
+                )
         }
     }
 
 
     @Test
     @DisplayName("특정 지점에서 범위 내 좌표 확인- 비로그인 - 사각형")
-    void t3_3_2() throws Exception {
+    @Throws(Exception::class)
+    fun t3_3_2() {
+        val pin = pinRepository.findAll()[0]
+        val centerLat = pin.point.y
+        val centerLon = pin.point.x
 
-        Pin pin = pinRepository.findAll().get(0);
-        double centerLat = pin.getPoint().getY();
-        double centerLon = pin.getPoint().getX();
+        val delta = 0.01 // 대략 1km 정도의 범위
+        val latMax = centerLat + delta
+        val latMin = centerLat - delta
+        val lonMax = centerLon + delta
+        val lonMin = centerLon - delta
 
-        double delta = 0.01; // 대략 1km 정도의 범위
-        double latMax = centerLat + delta;
-        double latMin = centerLat - delta;
-        double lonMax = centerLon + delta;
-        double lonMin = centerLon - delta;
+        val pins = pinRepository.findPublicScreenPins(latMax, lonMax, latMin, lonMin)
 
-        List<Pin> pins = pinRepository.findPublicScreenPins(latMax, lonMax, latMin, lonMin);
-
-        ResultActions resultActions = mvc
-                .perform(
-                        get("/api/pins/screen")
-                                .param("latMax", String.valueOf(latMax))
-                                .param("latMin", String.valueOf(latMin))
-                                .param("lonMax", String.valueOf(lonMax))
-                                .param("lonMin", String.valueOf(lonMin))
-                )
-                .andDo(print());
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.get("/api/pins/screen")
+                    .param("latMax", latMax.toString())
+                    .param("latMin", latMin.toString())
+                    .param("lonMax", lonMax.toString())
+                    .param("lonMin", lonMin.toString())
+            )
+            .andDo(MockMvcResultHandlers.print())
 
         resultActions
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("getRectanglePins"))
-                .andExpect(status().isOk());
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("getRectanglePins"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
 
         // 반환된 데이터의 개수 검증
-        resultActions.andExpect(jsonPath("$.data.length()").value(pins.size()));
+        resultActions.andExpect(MockMvcResultMatchers.jsonPath("$.data.length()").value(pins.size))
 
-        // 개별 요소 검증
-        for (int i = 0; i < pins.size(); i++) {
-            Pin p = pins.get(i);
+        for (i in pins.indices) {
             resultActions
-                    .andExpect(jsonPath("$.data[%d].id".formatted(i)).value(p.getId()))
-                    .andExpect(jsonPath("$.data[%d].latitude".formatted(i)).value(p.getPoint().getY()))
-                    .andExpect(jsonPath("$.data[%d].longitude".formatted(i)).value(p.getPoint().getX()))
-                    .andExpect(jsonPath("$.data[%d].pinTags.length()".formatted(i)).value(p.getPinTags().size()))
-                    .andExpect(jsonPath("$.data[%d].createdAt".formatted(i))
-                            .value(matchesPattern(p.getCreatedAt().toString().replaceAll("0+$", "") + ".*")))
-                    .andExpect(jsonPath("$.data[%d].modifiedAt".formatted(i))
-                            .value(matchesPattern(p.getModifiedAt().toString().replaceAll("0+$", "") + ".*")));
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[$i].id").value(pins[i].id))
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].latitude")
+                        .value(pins[i].point.y)
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].longitude")
+                        .value(pins[i].point.x)
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].createdAt").value(
+                        Matchers.matchesPattern(
+                            pins[i].createdAt.toString().replace("0+$".toRegex(), "") + ".*"
+                        )
+                    )
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].modifiedAt").value(
+                        Matchers.matchesPattern(
+                            pins[i].modifiedAt.toString().replace("0+$".toRegex(), "") + ".*"
+                        )
+                    )
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].pinTags.length()")
+                        .value(pins[i].pinTags.size)
+                )
         }
-
     }
 
     @Test
     @DisplayName("특정 지점에서 범위 내 핀 확인 - 핀 없음 - 사각형")
-    void t3_4() throws Exception {
-        double centerLat = 0;
-        double centerLon = 0;
+    @Throws(Exception::class)
+    fun t3_4() {
+        val centerLat = 0.0
+        val centerLon = 0.0
 
-        double delta = 0.01; // 대략 1km 정도의 범위
-        double latMax = centerLat + delta;
-        double latMin = centerLat - delta;
-        double lonMax = centerLon + delta;
-        double lonMin = centerLon - delta;
+        val delta = 0.01 // 대략 1km 정도의 범위
+        val latMax = centerLat + delta
+        val latMin = centerLat - delta
+        val lonMax = centerLon + delta
+        val lonMin = centerLon - delta
 
-        List<Pin> pins = pinRepository.findPublicScreenPins(latMax, lonMax, latMin, lonMin);
-
-        ResultActions resultActions = mvc
-                .perform(
-                        get("/api/pins/screen")
-                                .param("latMax", String.valueOf(latMax))
-                                .param("latMin", String.valueOf(latMin))
-                                .param("lonMax", String.valueOf(lonMax))
-                                .param("lonMin", String.valueOf(lonMin))
-                )
-                .andDo(print());
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.get("/api/pins/screen")
+                    .param("latMax", latMax.toString())
+                    .param("latMin", latMin.toString())
+                    .param("lonMax", lonMax.toString())
+                    .param("lonMin", lonMin.toString())
+            )
+            .andDo(MockMvcResultHandlers.print())
 
 
         resultActions
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("getRectanglePins"))
-                .andExpect(jsonPath("$.errorCode").value("200"))
-                .andExpect(jsonPath("$.msg").exists())
-                .andExpect(jsonPath("$.data").isEmpty());
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("getRectanglePins"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.errorCode").value("200"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.msg").exists())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data").isEmpty())
     }
 
 
     @Test
     @DisplayName("모든 핀 리턴")
-    void t4_1_1() throws Exception {
-        List<Pin> pins = pinRepository.findAllAccessiblePins(testUser.getId());
+    @Throws(Exception::class)
+    fun t4_1_1() {
+        val pins = pinRepository.findAllAccessiblePins(testUser.id)
 
-        ResultActions resultActions = mvc
-                .perform(
-                        get("/api/pins/all")
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                )
-                .andDo(print());
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.get("/api/pins/all")
+                    .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+            )
+            .andDo(MockMvcResultHandlers.print())
 
         resultActions
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("getAll"))
-                .andExpect(status().isOk());
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("getAll"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
 
-        for (int i = 0; i < pins.size(); i++) {
+        for (i in pins.indices) {
             resultActions
-                    .andExpect(jsonPath("$.data[%d].id".formatted(i)).value(pins.get(i).getId()))
-                    .andExpect(jsonPath("$.data[%d].latitude".formatted(i)).value(pins.get(i).getPoint().getY()))
-                    .andExpect(jsonPath("$.data[%d].longitude".formatted(i)).value(pins.get(i).getPoint().getX()))
-                    .andExpect(jsonPath("$.data[%d].createdAt".formatted(i)).value(matchesPattern(pins.get(i).getCreatedAt().toString().replaceAll("0+$", "") + ".*")))
-                    .andExpect(jsonPath("$.data[%d].pinTags.length()".formatted(i)).value(pins.get(i).getPinTags().size()));
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[$i].id").value(pins[i].id))
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].latitude")
+                        .value(pins[i].point.y)
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].longitude")
+                        .value(pins[i].point.x)
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].createdAt").value(
+                        Matchers.matchesPattern(
+                            pins[i].createdAt.toString().replace("0+$".toRegex(), "") + ".*"
+                        )
+                    )
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].modifiedAt").value(
+                        Matchers.matchesPattern(
+                            pins[i].modifiedAt.toString().replace("0+$".toRegex(), "") + ".*"
+                        )
+                    )
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].pinTags.length()")
+                        .value(pins[i].pinTags.size)
+                )
         }
     }
 
     @Test
     @DisplayName("모든 핀 리턴 - 비로그인")
-    void t4_1_2() throws Exception {
-        List<Pin> pins = pinRepository.findAllPublicPins();
+    @Throws(Exception::class)
+    fun t4_1_2() {
+        val pins = pinRepository.findAllPublicPins()
 
-        ResultActions resultActions = mvc
-                .perform(
-                        get("/api/pins/all")
-                )
-                .andDo(print());
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.get("/api/pins/all")
+            )
+            .andDo(MockMvcResultHandlers.print())
 
         resultActions
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("getAll"))
-                .andExpect(status().isOk());
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("getAll"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
 
-        for (int i = 0; i < pins.size(); i++) {
+        for (i in pins.indices) {
             resultActions
-                    .andExpect(jsonPath("$.data[%d].id".formatted(i)).value(pins.get(i).getId()))
-                    .andExpect(jsonPath("$.data[%d].latitude".formatted(i)).value(pins.get(i).getPoint().getY()))
-                    .andExpect(jsonPath("$.data[%d].longitude".formatted(i)).value(pins.get(i).getPoint().getX()))
-                    .andExpect(jsonPath("$.data[%d].createdAt".formatted(i)).value(matchesPattern(pins.get(i).getCreatedAt().toString().replaceAll("0+$", "") + ".*")))
-                    .andExpect(jsonPath("$.data[%d].pinTags.length()".formatted(i)).value(pins.get(i).getPinTags().size()));
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[$i].id").value(pins[i].id))
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].latitude")
+                        .value(pins[i].point.y)
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].longitude")
+                        .value(pins[i].point.x)
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].createdAt").value(
+                        Matchers.matchesPattern(
+                            pins[i].createdAt.toString().replace("0+$".toRegex(), "") + ".*"
+                        )
+                    )
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].modifiedAt").value(
+                        Matchers.matchesPattern(
+                            pins[i].modifiedAt.toString().replace("0+$".toRegex(), "") + ".*"
+                        )
+                    )
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].pinTags.length()")
+                        .value(pins[i].pinTags.size)
+                )
         }
     }
 
     @Test
     @DisplayName("특정 사용자 핀 리턴 -성공 ")
-    void t4_2_1() throws Exception {
-        User testUser = userRepository.getReferenceById(1L);
-        List<Pin> pins = pinRepository.findAccessibleByUser(testUser.getId(), testUser.getId());
+    @Throws(Exception::class)
+    fun t4_2_1() {
+        val testUser = userRepository.getReferenceById(1L)
+        val pins = pinRepository.findAccessibleByUser(testUser.id, testUser.id)
 
-        ResultActions resultActions = mvc
-                .perform(
-                        get("/api/pins/user/%s".formatted(targetId))
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                )
-                .andDo(print());
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.get("/api/pins/user/$targetId")
+                    .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+            )
+            .andDo(MockMvcResultHandlers.print())
 
         resultActions
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("getUserPins"))
-                .andExpect(status().isOk());
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("getUserPins"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
 
-        for (int i = 0; i < pins.size(); i++) {
+        for (i in pins.indices) {
             resultActions
-                    .andExpect(jsonPath("$.data[%d].id".formatted(i)).value(pins.get(i).getId()))
-                    .andExpect(jsonPath("$.data[%d].latitude".formatted(i)).value(pins.get(i).getPoint().getY()))
-                    .andExpect(jsonPath("$.data[%d].longitude".formatted(i)).value(pins.get(i).getPoint().getX()))
-                    .andExpect(jsonPath("$.data[%d].createdAt".formatted(i)).value(matchesPattern(pins.get(i).getCreatedAt().toString().replaceAll("0+$", "") + ".*")))
-                    .andExpect(jsonPath("$.data[%d].pinTags.length()".formatted(i)).value(pins.get(i).getPinTags().size()));
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[$i].id").value(pins[i].id))
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].latitude")
+                        .value(pins[i].point.y)
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].longitude")
+                        .value(pins[i].point.x)
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].createdAt").value(
+                        Matchers.matchesPattern(
+                            pins[i].createdAt.toString().replace("0+$".toRegex(), "") + ".*"
+                        )
+                    )
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].modifiedAt").value(
+                        Matchers.matchesPattern(
+                            pins[i].modifiedAt.toString().replace("0+$".toRegex(), "") + ".*"
+                        )
+                    )
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].pinTags.length()")
+                        .value(pins[i].pinTags.size)
+                )
         }
     }
 
     @Test
     @DisplayName("특정 사용자 핀 리턴 - 비로그인 - 성공 ")
-    void t4_2_2() throws Exception {
-        User testUser = userRepository.getReferenceById(1L);
-        List<Pin> pins = pinRepository.findPublicByUser(testUser.getId());
+    @Throws(Exception::class)
+    fun t4_2_2() {
+        val testUser = userRepository.getReferenceById(1L)
+        val pins = pinRepository.findPublicByUser(testUser.id)
 
-        ResultActions resultActions = mvc
-                .perform(
-                        get("/api/pins/user/%s".formatted(targetId))
-                )
-                .andDo(print());
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.get("/api/pins/user/$targetId")
+            )
+            .andDo(MockMvcResultHandlers.print())
 
         resultActions
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("getUserPins"))
-                .andExpect(status().isOk());
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("getUserPins"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
 
-        for (int i = 0; i < pins.size(); i++) {
+        for (i in pins.indices) {
             resultActions
-                    .andExpect(jsonPath("$.data[%d].id".formatted(i)).value(pins.get(i).getId()))
-                    .andExpect(jsonPath("$.data[%d].latitude".formatted(i)).value(pins.get(i).getPoint().getY()))
-                    .andExpect(jsonPath("$.data[%d].longitude".formatted(i)).value(pins.get(i).getPoint().getX()))
-                    .andExpect(jsonPath("$.data[%d].createdAt".formatted(i)).value(matchesPattern(pins.get(i).getCreatedAt().toString().replaceAll("0+$", "") + ".*")))
-                    .andExpect(jsonPath("$.data[%d].pinTags.length()".formatted(i)).value(pins.get(i).getPinTags().size()));
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[$i].id").value(pins[i].id))
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].latitude")
+                        .value(pins[i].point.y)
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].longitude")
+                        .value(pins[i].point.x)
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].createdAt").value(
+                        Matchers.matchesPattern(
+                            pins[i].createdAt.toString().replace("0+$".toRegex(), "") + ".*"
+                        )
+                    )
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].modifiedAt").value(
+                        Matchers.matchesPattern(
+                            pins[i].modifiedAt.toString().replace("0+$".toRegex(), "") + ".*"
+                        )
+                    )
+                )
+                .andExpect(
+                    MockMvcResultMatchers.jsonPath("$.data[$i].pinTags.length()")
+                        .value(pins[i].pinTags.size)
+                )
         }
     }
 
     @Test
     @DisplayName("특정 사용자 핀 리턴 -실패 ")
-    void t4_3() throws Exception {
-
-        ResultActions resultActions = mvc
-                .perform(
-                        get("/api/pins/user/%s".formatted(failedTargetId))
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                )
-                .andDo(print());
+    @Throws(Exception::class)
+    fun t4_3() {
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.get("/api/pins/user/$failedTargetId")
+                    .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+            )
+            .andDo(MockMvcResultHandlers.print())
 
         resultActions
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("getUserPins"))
-                .andExpect(status().isNotFound());
-
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("getUserPins"))
+            .andExpect(MockMvcResultMatchers.status().isNotFound())
     }
 
     @Test
     @DisplayName("핀 내용 수정")
-    void t5_1_1() throws Exception {
+    @Throws(Exception::class)
+    fun t5_1_1() {
+        val content = "updated Content!"
+        val pin = pinRepository.findById(targetId).get()
 
-        String content = "updated Content!";
-        Pin pin = pinRepository.findById(targetId).get();
-
-        ResultActions resultActions = mvc
-                .perform(
-                        put("/api/pins/%s".formatted(targetId))
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content("""
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.put("/api/pins/$targetId")
+                    .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
                                         {
-                                            "content": "%s"
+                                            "content": "$content"
                                         }
-                                        """.formatted(content))
-                )
-                .andDo(print());
+                                        
+                                        """.trimIndent()
+                    )
+            )
+            .andDo(MockMvcResultHandlers.print())
 
         resultActions
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("updatePinContent"))
-                .andExpect(status().isOk());
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("updatePinContent"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
 
         resultActions
-                .andExpect(jsonPath("$.data.id").value(targetId))
-                .andExpect(jsonPath("$.data.latitude").value(pin.getPoint().getY()))
-                .andExpect(jsonPath("$.data.longitude").value(pin.getPoint().getX()))
-                .andExpect(jsonPath("$.data.content").value(content));
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.id").value(targetId))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.latitude").value(pin.point.y))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.longitude").value(pin.point.x))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.content").value(content))
     }
 
     @Test
     @DisplayName("핀 내용 수정 - 실패 (id없음)")
-    void t5_1_2() throws Exception {
-
-        String content = "updated Content!";
-        ResultActions resultActions = mvc
-                .perform(
-                        put("/api/pins/%s".formatted(failedTargetId))
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content("""
+    @Throws(Exception::class)
+    fun t5_1_2() {
+        val content = "updated Content!"
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.put("/api/pins/$failedTargetId")
+                    .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
                                         {
-                                            "content": "%s"
+                                            "content": "$content"
                                         }
-                                        """.formatted(content))
-                )
-                .andDo(print());
+                                        
+                                        """.trimIndent()
+                    )
+            )
+            .andDo(MockMvcResultHandlers.print())
 
         resultActions
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("updatePinContent"))
-                .andExpect(jsonPath("$.errorCode").value("1002"))
-                .andExpect(jsonPath("$.msg").exists());
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("updatePinContent"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.errorCode").value("1002"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.msg").exists())
     }
 
     @Test
     @DisplayName("핀 내용 수정 - 실패 (내용 없음)")
-    void t5_1_3() throws Exception {
-        ResultActions resultActions = mvc
-                .perform(
-                        put("/api/pins/%s".formatted(targetId))
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content("{}")
-                )
-                .andDo(print());
+    @Throws(Exception::class)
+    fun t5_1_3() {
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.put("/api/pins/$targetId")
+                    .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{}")
+            )
+            .andDo(MockMvcResultHandlers.print())
 
         resultActions
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("updatePinContent"))
-                .andExpect(jsonPath("$.errorCode").value("1005"))
-                .andExpect(jsonPath("$.msg").exists());
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("updatePinContent"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.errorCode").value("1005"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.msg").exists())
     }
 
     @Test
     @DisplayName("핀 내용 수정 - 실패 (권한 없음)")
-    void t5_1_4() throws Exception {
-        String content = "updated Content!";
-        ResultActions resultActions = mvc
-                .perform(
-                        put("/api/pins/%s".formatted(noAuthId))
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content("""
+    @Throws(Exception::class)
+    fun t5_1_4() {
+        val content = "updated Content!"
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.put("/api/pins/$noAuthId")
+                    .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
                                         {
-                                            "content": "%s"
+                                            "content": "$content"
                                         }
-                                        """.formatted(content))
-                )
-                .andDo(print());
+                                        
+                                        """.trimIndent()
+                    )
+            )
+            .andDo(MockMvcResultHandlers.print())
 
         resultActions
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("updatePinContent"))
-                .andExpect(jsonPath("$.errorCode").value("1010"))
-                .andExpect(jsonPath("$.msg").exists());
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("updatePinContent"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.errorCode").value("1010"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.msg").exists())
     }
 
 
     @Test
     @DisplayName("핀 공개 여부 수정")
-    void t5_2_1() throws Exception {
+    @Throws(Exception::class)
+    fun t5_2_1() {
+        val pin = pinRepository.findById(targetId).get()
 
-        Pin pin = pinRepository.findById(targetId).get();
+        val expectedIsPublicString = (!pin.isPublic).toString()
 
-        String expectedIsPublicString = String.valueOf(!pin.getIsPublic());
-
-        ResultActions resultActions = mvc
-                .perform(
-                        put("/api/pins/%s/public".formatted(targetId))
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content("{}")
-                )
-                .andDo(print());
-
-        resultActions
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("changePinPublic"))
-                .andExpect(status().isOk());
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.put("/api/pins/$targetId/public")
+                    .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{}")
+            )
+            .andDo(MockMvcResultHandlers.print())
 
         resultActions
-                .andExpect(jsonPath("$.data.id").value(targetId))
-                .andExpect(jsonPath("$.data.isPublic").value(expectedIsPublicString));
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("changePinPublic"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+
+        resultActions
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.id").value(targetId))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.isPublic").value(expectedIsPublicString))
     }
 
     @Test
     @DisplayName("핀 공개 여부 수정 - 실패 (id 없음)")
-    void t5_2_2() throws Exception {
-        ResultActions resultActions = mvc
-                .perform(
-                        put("/api/pins/%s/public".formatted(failedTargetId))
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content("{}")
-                )
-                .andDo(print());
+    @Throws(Exception::class)
+    fun t5_2_2() {
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.put("/api/pins/$failedTargetId/public")
+                    .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{}")
+            )
+            .andDo(MockMvcResultHandlers.print())
 
         resultActions
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("changePinPublic"))
-                .andExpect(jsonPath("$.errorCode").value("1002"))
-                .andExpect(jsonPath("$.msg").exists());
-
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("changePinPublic"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.errorCode").value("1002"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.msg").exists())
     }
 
     @Test
     @DisplayName("핀 공개 여부 수정 - 실패 (권한 없음)")
-    void t5_2_3() throws Exception {
-
-        ResultActions resultActions = mvc
-                .perform(
-                        put("/api/pins/%s/public".formatted(noAuthId))
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content("{}")
-                )
-                .andDo(print());
+    @Throws(Exception::class)
+    fun t5_2_3() {
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.put("/api/pins/$noAuthId/public")
+                    .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{}")
+            )
+            .andDo(MockMvcResultHandlers.print())
 
         resultActions
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("changePinPublic"))
-                .andExpect(jsonPath("$.errorCode").value("1010"))
-                .andExpect(jsonPath("$.msg").exists());
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("changePinPublic"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.errorCode").value("1010"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.msg").exists())
     }
 
     @Test
     @DisplayName("핀 삭제 - 성공")
-    void t6_1() throws Exception {
-
-        ResultActions resultActions = mvc
-                .perform(
-                        delete("/api/pins/%s".formatted(targetId))
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                )
-                .andDo(print());
+    @Throws(Exception::class)
+    fun t6_1() {
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.delete("/api/pins/$targetId")
+                    .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+            )
+            .andDo(MockMvcResultHandlers.print())
 
         resultActions
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("deletePin"))
-                .andExpect(status().isOk());
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("deletePin"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
     }
 
     @Test
     @DisplayName("핀 삭제 - 실패 (id없음)")
-    void t6_2() throws Exception {
-
-        ResultActions resultActions = mvc
-                .perform(
-                        delete("/api/pins/%s".formatted(failedTargetId))
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                )
-                .andDo(print());
+    @Throws(Exception::class)
+    fun t6_2() {
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.delete("/api/pins/$failedTargetId")
+                    .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+            )
+            .andDo(MockMvcResultHandlers.print())
 
         resultActions
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("deletePin"))
-                .andExpect(jsonPath("$.errorCode").value("1002"))
-                .andExpect(jsonPath("$.msg").exists());
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("deletePin"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.errorCode").value("1002"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.msg").exists())
     }
 
     @Test
     @DisplayName("핀 삭제 - 실패 (권한 없음)")
-    void t6_3() throws Exception {
-
-        ResultActions resultActions = mvc
-                .perform(
-                        delete("/api/pins/%s".formatted(noAuthId))
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                )
-                .andDo(print());
+    @Throws(Exception::class)
+    fun t6_3() {
+        val resultActions = mvc
+            .perform(
+                MockMvcRequestBuilders.delete("/api/pins/$noAuthId")
+                    .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+            )
+            .andDo(MockMvcResultHandlers.print())
 
         resultActions
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("deletePin"))
-                .andExpect(jsonPath("$.errorCode").value("1010"))
-                .andExpect(jsonPath("$.msg").exists());
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("deletePin"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.errorCode").value("1010"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.msg").exists())
     }
 
 
     @Test
     @DisplayName("좋아요 저장 성공")
     @Transactional
-    void 좋아요등록성공() throws Exception {
+    @Throws(Exception::class)
+    fun t7_1() {
         //given
-        Long pinId = 5L;
-        Long userId = 2L;
-        String requestBody = "{\"userId\": " + userId + "}";
-        User testUser = userService.findById(userId);
+        val pinId = 5L
+        val userId = 2L
+        val requestBody = "{\"userId\": $userId}"
+        val testUser = userService.findById(userId)
 
-        int likeCnt = likesService.getLikesCount(pinId);
+        val likeCnt = likesService.getLikesCount(pinId)
 
         // when & then
         mvc.perform(
-                        post("/api/pins/{pinId}/likes", pinId)
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(requestBody)
-//                                .with(csrf())
-//                                .with(user("testuser").roles("USER"))  // 인증 사용자 추가
-                )
-                .andDo(print())
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.errorCode").value("200"))
+            MockMvcRequestBuilders.post("/api/pins/$pinId/likes" )
+                .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody) //                                .with(csrf())
+            //                                .with(user("testuser").roles("USER"))  // 인증 사용자 추가
+        )
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.errorCode").value("200"))
 
-                .andExpect(jsonPath("$.data.isLiked").value(true))
-                .andExpect(jsonPath("$.data.likeCount").value(likeCnt + 1));
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.isLiked").value(true))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.likeCount").value(likeCnt + 1))
 
         // DB 검증
-        Likes likes = likesRepository.findByPinIdAndUserId(pinId, userId)
-                .orElseThrow(() -> new ServiceException(ErrorCode.LIKES_CREATE_FAILED));
-//        assertThat(likes.getLiked()).isTrue();
-        assertThat(likes.getPin().getId()).isEqualTo(pinId);
-        assertThat(likes.getUser().getId()).isEqualTo(userId);
-        assertThat(likes.getCreatedAt()).isNotNull();
+        val likes = likesRepository.findByPinIdAndUserId(pinId, userId)
+            .orElseThrow(Supplier { ServiceException(ErrorCode.LIKES_CREATE_FAILED) })
+        //        assertThat(likes.getLiked()).isTrue();
+        Assertions.assertThat(likes.pin.id).isEqualTo(pinId)
+        Assertions.assertThat(likes.user.id).isEqualTo(userId)
+        Assertions.assertThat(likes.createdAt).isNotNull()
     }
 
     @Test
     @DisplayName("좋아요 저장 실패 - 존재하지 않는 핀")
     @Transactional
-    void likesCreatefailPinId() throws Exception {
+    @Throws(Exception::class)
+    fun t7_2() {
         // given
-        Long pinId = 99999L;
-        Long userId = 2L;
-        String requestBody = "{\"userId\": " + userId + "}";
-        User testUser = userService.findById(userId);
+        val pinId = 99999L
+        val userId = 2L
+        val requestBody = "{\"userId\": $userId}"
+        val testUser = userService.findById(userId)
 
         // when & then
         mvc.perform(
-                        post("/api/pins/{pinId}/likes", pinId)
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(requestBody)
-//                                .with(csrf())
-//                                .with(user("testuser").roles("USER"))
-                )
-                .andDo(print())
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.errorCode").value("5002"))
-                .andExpect(jsonPath("$.msg").value("잘못된 핀 정보입니다."));
+            MockMvcRequestBuilders.post("/api/pins/$pinId/likes")
+                .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody) //                                .with(csrf())
+            //                                .with(user("testuser").roles("USER"))
+        )
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(MockMvcResultMatchers.status().isNotFound())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.errorCode").value("5002"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.msg").value("잘못된 핀 정보입니다."))
 
         // DB 검증
-        Optional<Likes> likes = likesRepository.findByPinIdAndUserId(pinId, userId);
-        assertThat(likes).isEmpty();
+        val likes = likesRepository.findByPinIdAndUserId(pinId, userId)
+        Assertions.assertThat(likes).isEmpty()
     }
 
-//    @Test
-//    @DisplayName("좋아요 저장 실패 - 존재하지 않는 사용자 - 테스트 불가")
-//    @Transactional
-//    void likesCreatefailUserId() throws Exception {
-//        // 인증 도입으로 존재하지 않는 사용자 테스트 불가
-//        // given
-//        Long pinId = 2L;
-//        Long userId = 999L;
-//        String requestBody = "{\"userId\": " + userId + "}";
-//        User testUser = userService.findById(userId);
-//
-//        // when & then
-//        mvc.perform(
-//                        post("/api/pins/{pinId}/likes", pinId)
-//                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-//                                .contentType(MediaType.APPLICATION_JSON)
-//                                .content(requestBody)
-////                                .with(csrf())
-////                                .with(user("testuser").roles("USER"))
-//                )
-//                .andDo(print())
-//                .andExpect(status().isNotFound())
-//                .andExpect(jsonPath("$.errorCode").value("2006"));
-//
-//        // DB 검증
-//        Optional<Likes> likes = likesRepository.findByPinIdAndUserId(pinId, userId);
-//        assertThat(likes).isEmpty();
-//    }
-
+    //    @Test
+    //    @DisplayName("좋아요 저장 실패 - 존재하지 않는 사용자 - 테스트 불가")
+    //    @Transactional
+    //    void likesCreatefailUserId() throws Exception {
+    //        // 인증 도입으로 존재하지 않는 사용자 테스트 불가
+    //        // given
+    //        Long pinId = 2L;
+    //        Long userId = 999L;
+    //        String requestBody = "{\"userId\": " + userId + "}";
+    //        User testUser = userService.findById(userId);
+    //
+    //        // when & then
+    //        mvc.perform(
+    //                        post("/api/pins/{pinId}/likes", pinId)
+    //                                .header("Authorization", "Bearer ${testUser.getApiKey()} $jwtToken")
+    //                                .contentType(MediaType.APPLICATION_JSON)
+    //                                .content(requestBody)
+    //                                .with(csrf())
+    //                                .with(user("testuser").roles("USER")) */
+    //                )
+    //                .andDo(print())
+    //                .andExpect(status().isNotFound())
+    //                .andExpect(jsonPath("$.errorCode").value("2006"));
+    //
+    //        // DB 검증
+    //        Optional<Likes> likes = likesRepository.findByPinIdAndUserId(pinId, userId);
+    //        assertThat(likes).isEmpty();
+    //    }
     @Test
     @DisplayName("좋아요 취소 성공 - 좋아요 true")
     @Transactional
-    void likesDeleteTSuccess() throws Exception {
+    @Throws(Exception::class)
+    fun t8_1() {
         //given
-        Long pinId = 1L;
-        Long userId = 1L;
-        String requestBody = "{\"userId\": " + userId + "}";
-        int lcount = likesService.getLikesCount(pinId);
+        val pinId = 1L
+        val userId = 1L
+        val requestBody = "{\"userId\": $userId}"
+        val lcount = likesService.getLikesCount(pinId)
 
 
         // when & then
         mvc.perform(
-                        delete("/api/pins/{pinId}/likes", pinId)
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(requestBody)
-//                                .with(csrf())
-//                                .with(user("testuser").roles("USER"))  // 인증 사용자 추가
-                )
-                .andDo(print())
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.errorCode").value("200"))
+            MockMvcRequestBuilders.delete("/api/pins/$pinId/likes")
+                .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody) //                                .with(csrf())
+            //                                .with(user("testuser").roles("USER"))  // 인증 사용자 추가
+        )
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.errorCode").value("200"))
 
-                .andExpect(jsonPath("$.data.isLiked").value(false))
-                .andExpect(jsonPath("$.data.likeCount").value(lcount - 1));
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.isLiked").value(false))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.likeCount").value(lcount - 1))
 
         // DB 검증
-        Likes likes = likesRepository.findByPinIdAndUserId(pinId, userId).orElse(null);
-        assertThat(likes).isNull();
+        val likes = likesRepository.findByPinIdAndUserId(pinId, userId).orElse(null)
+        Assertions.assertThat(likes).isNull()
     }
 
     @Test
     @DisplayName("좋아요 취소 다시 좋아요 성공 - 좋아요 true")
     @Transactional
-    void likesDeleteFSuccess() throws Exception {
+    @Throws(Exception::class)
+    fun t8_2() {
         //given
-        Long pinId = 4L;
-        Long userId = 1L;
-        String requestBody = "{\"userId\": " + userId + "}";
+        val pinId = 4L
+        val userId = 1L
+        val requestBody = "{\"userId\": $userId}"
 
         // when & then
         mvc.perform(
-                        post("/api/pins/{pinId}/likes", pinId)
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(requestBody)
-//                                .with(csrf())
-//                                .with(user("testuser").roles("USER"))  // 인증 사용자 추가
-                )
-                .andDo(print())
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.errorCode").value("200"))
+            MockMvcRequestBuilders.post("/api/pins/$pinId/likes")
+                .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody) //                                .with(csrf())
+            //                                .with(user("testuser").roles("USER"))  // 인증 사용자 추가
+        )
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.errorCode").value("200"))
 
-                .andExpect(jsonPath("$.data.isLiked").value(true))
-                .andExpect(jsonPath("$.data.likeCount").value(1));
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.isLiked").value(true))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.likeCount").value(1))
 
         // DB 검증
-        Likes likes = likesRepository.findByPinIdAndUserId(pinId, userId)
-                .orElseThrow(() -> new ServiceException(ErrorCode.LIKES_CREATE_FAILED));
-        assertThat(likes.getPin().getId()).isEqualTo(pinId);
-        assertThat(likes.getUser().getId()).isEqualTo(userId);
-        assertThat(likes.getModifiedAt()).isNotNull();
+        val likes = likesRepository.findByPinIdAndUserId(pinId, userId)
+            .orElseThrow(Supplier { ServiceException(ErrorCode.LIKES_CREATE_FAILED) })
+        Assertions.assertThat(likes.pin.id).isEqualTo(pinId)
+        Assertions.assertThat(likes.user.id).isEqualTo(userId)
+        Assertions.assertThat(likes.modifiedAt).isNotNull()
     }
 
 
     @Test
     @DisplayName("좋아요 토글 성공 - 좋아요 취소 -> 등록")
     @Transactional
-    void likseToggleTF() throws Exception {
+    @Throws(Exception::class)
+    fun likseToggleTF() {
         // given
-        Long pinId = 2L;
-        Long userId = 1L;
-        String requestBody = "{\"userId\": " + userId + "}";
+        val pinId = 2L
+        val userId = 1L
+        val requestBody = "{\"userId\": $userId}"
 
         // when & then
         mvc.perform(
-                        delete("/api/pins/{pinId}/likes", pinId)
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(requestBody)
-//                                .with(csrf())
-//                                .with(user("testuser").roles("USER"))
-                )
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.errorCode").value("200"))
-                .andExpect(jsonPath("$.data.isLiked").value(false));
+            MockMvcRequestBuilders.delete("/api/pins/$pinId/likes")
+                .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody) //                                .with(csrf())
+            //                                .with(user("testuser").roles("USER"))
+        )
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.errorCode").value("200"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.isLiked").value(false))
 
         // DB 검증
-        Likes likes = likesRepository.findByPinIdAndUserId(pinId, userId).orElse(null);
-        assertThat(likes).isNull();
+        val likes = likesRepository.findByPinIdAndUserId(pinId, userId).orElse(null)
+        Assertions.assertThat(likes).isNull()
 
         // 좋아요 재등록
         mvc.perform(
-                        post("/api/pins/{pinId}/likes", pinId)
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(requestBody)
-//                                .with(csrf())
-//                                .with(user("testuser").roles("USER"))
-                )
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.errorCode").value("200"))
-                .andExpect(jsonPath("$.data.isLiked").value(true));
+            MockMvcRequestBuilders.post("/api/pins/{pinId}/likes", pinId)
+                .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody) //                                .with(csrf())
+            //                                .with(user("testuser").roles("USER"))
+        )
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.errorCode").value("200"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.isLiked").value(true))
 
         // DB 검증
-        likes = likesRepository.findByPinIdAndUserId(pinId, userId)
-                .orElseThrow(() -> new ServiceException(ErrorCode.LIKES_CREATE_FAILED));
+        likesRepository.findByPinIdAndUserId(pinId, userId)
+            .orElseThrow(Supplier { ServiceException(ErrorCode.LIKES_CREATE_FAILED) })
     }
 
 
     @Test
     @DisplayName("좋아요 개수 가져오기 성공 - 특정 핀 조회")
     @Transactional
-    void likeGetLikeCountTByPin() throws Exception {
+    @Throws(Exception::class)
+    fun likeGetLikeCountTByPin() {
         // given
-        Long pinId = 1L;
-        User testUser = userService.findById(1L);
-        Pin pin = pinService.findById(pinId, userService.findById(1L));
+        val pinId = 1L
+        val testUser = userService.findById(1L)
+        val pin = pinService.findById(pinId, userService.findById(1L))
 
         // when & then
         mvc.perform(
-                        get("/api/pins/{pinId}", pinId)
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                )
-                .andDo(print())
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("getPinById"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.errorCode").value("200"))
+            MockMvcRequestBuilders.get("/api/pins/$pinId")
+                .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+        )
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("getPinById"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.errorCode").value("200"))
 
-                .andExpect(jsonPath("$.data.id").value(pin.getId()))
-                .andExpect(jsonPath("$.data.likeCount").value(likesRepository.countByPinId(pinId)));
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.id").value(pin.id))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.likeCount").value(likesRepository.countByPinId(pinId)))
     }
 
     @Test
     @DisplayName("좋아요 개수 가져오기 성공 - 취소된 핀")
-    void likeGetLikeCountByPin() throws Exception {
+    @Throws(Exception::class)
+    fun likeGetLikeCountByPin() {
         // given
-        Long pinId = 4L;
-        User user = userService.findById(1L);
-        Pin pin = pinService.findById(pinId, testUser);
+        val pinId = 4L
+        val pin = pinService.findById(pinId, testUser)
 
         // when & then
         mvc.perform(
-                        get("/api/pins/{pinId}", pinId)
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-                )
-                .andDo(print())
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("getPinById"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.errorCode").value("200"))
+            MockMvcRequestBuilders.get("/api/pins/$pinId")
+                .header("Authorization", "Bearer ${testUser.apiKey} $jwtToken")
+        )
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("getPinById"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.errorCode").value("200"))
 
-                .andExpect(jsonPath("$.data.id").value(pin.getId()))
-                .andExpect(jsonPath("$.data.likeCount").value(0));
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.id").value(pin.id))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.likeCount").value(0))
     }
 
 
     @Test
     @DisplayName("좋아요한 사용자 목록 조회 성공")
-    void likesGetUsersWhoLikedPin() throws Exception {
+    @Throws(Exception::class)
+    fun likesGetUsersWhoLikedPin() {
         // given
-        Long pinId = 1L;
+        val pinId = 1L
 
-        Integer[] userIds = likesRepository.findUsersByPinId(pinId)
-                .stream()
-                .map(User::getId)
-                .map(id -> id.intValue())
-                .toArray(Integer[]::new);
+        val userIds = likesRepository.findUsersByPinId(pinId)
+            .map { it.id.toInt() }
+            .toTypedArray()
+
 
         // when & then
         mvc.perform(
-                        get("/api/pins/{pinId}/likesusers", pinId)
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-//                                .with(csrf())
-//                                .with(user("testuser").roles("USER"))  // 인증 사용자 추가
-                )
-                .andDo(print())
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("getUsersWhoLikedPin"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.errorCode").value("200"))
+            MockMvcRequestBuilders.get("/api/pins/$pinId/likesusers")
+                .header(
+                    "Authorization",
+                    "Bearer ${testUser.apiKey} $jwtToken"
+                ) //                                .with(csrf())
+            //                                .with(user("testuser").roles("USER"))  // 인증 사용자 추가
+        )
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("getUsersWhoLikedPin"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.errorCode").value("200"))
 
-                .andExpect(jsonPath("$.data").isArray())
-                .andExpect(jsonPath("$.data.length()").value(likesRepository.countByPinId(pinId)))
-                .andExpect(jsonPath("$.data[*].id", containsInAnyOrder(userIds)));
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data").isArray())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.length()").value(likesRepository.countByPinId(pinId)))
+            .andExpect(
+                MockMvcResultMatchers.jsonPath(
+                    "$.data[*].id",
+                    Matchers.containsInAnyOrder(*userIds)
+                )
+            )
     }
 
     @Test
     @DisplayName("좋아요한 사용자 목록 조회 성공 - 취소건")
-    void likesGetUsersWhoLikedPinF() throws Exception {
+    @Throws(Exception::class)
+    fun likesGetUsersWhoLikedPinF() {
         // given
-        Long pinId = 4L;
+        val pinId = 4L
 
-        Integer[] userIds = likesRepository.findUsersByPinId(pinId)
-                .stream()
-                .map(User::getId)
-                .map(id -> id.intValue())
-                .toArray(Integer[]::new);
+        val userIds = likesRepository.findUsersByPinId(pinId)
+            .map { it.id.toInt() }
+            .toTypedArray()
+
 
         // when & then
         mvc.perform(
-                        get("/api/pins/{pinId}/likesusers", pinId)
-                                .header("Authorization", "Bearer %s %s".formatted(testUser.getApiKey(), jwtToken))
-//                                .with(csrf())
-//                                .with(user("testuser").roles("USER"))  // 인증 사용자 추가
-                )
-                .andDo(print())
-                .andExpect(handler().handlerType(PinController.class))
-                .andExpect(handler().methodName("getUsersWhoLikedPin"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.errorCode").value("200"))
+            MockMvcRequestBuilders.get("/api/pins/$pinId/likesusers")
+                .header(
+                    "Authorization",
+                    "Bearer ${testUser.apiKey} $jwtToken"
+                ) //                                .with(csrf())
+            //                                .with(user("testuser").roles("USER"))  // 인증 사용자 추가
+        )
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(MockMvcResultMatchers.handler().handlerType(PinController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("getUsersWhoLikedPin"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.errorCode").value("200"))
 
-                .andExpect(jsonPath("$.data").isArray())
-                .andExpect(jsonPath("$.data.length()").value(0))
-                .andExpect(jsonPath("$.data[*].id", containsInAnyOrder(userIds)));
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data").isArray())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.length()").value(0))
+            .andExpect(
+                MockMvcResultMatchers.jsonPath(
+                    "$.data[*].id",
+                    Matchers.containsInAnyOrder(*userIds)
+                )
+            )
     }
 }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
Security 도메인 파일들 코틀린 전환

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
Security 도메인에 있는 파일(CustomAuthenticationFilter, JwtTokenProvider, SecurityConfig) 코틀린으로 전환

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
코틀린 전환 후에  컴파일 할 때 lombok 이 잘 안 돌아서 ErrorCode 의 status, code, message getter 를 못 받아오고 있습니다. 그래서 잘 돌아가는지 확인해보실 때는 ErrorCode 에 getCode(), getStatus(), getMessage() 만든 후에 코드 실행하면 정상적으로 돌아갑니다!